### PR TITLE
docs: add 'How to Test' subsection to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,13 +18,7 @@
 
 ### How to Test
 
-- Describe via screen share recording or screenshots and text how to _manually_ test the new behavior.
-- Where applicable, include example queries, CLI commands, URLs to hit, UI elements to click, etc.
-  - Include expected results.
-  - Indicate if authorization is required.
-- The "happy path" should be included at the very least. Additional scenarios are encouraged.
-  - It is up to the code reviewers to go beyond the "happy path."
-  - It is up to the author to perform thorough manual testing before submitting a PR.
+<!-- ✍️ Describe how to _manually_ test the new behavior -->
 
 ## Other information
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,16 @@
 
 <!-- ✍️ Describe or provide screenshots of the changes introduced -->
 
+### How to Test
+
+- Describe via screen share recording or screenshots and text how to _manually_ test the new behavior.
+- Where applicable, include example queries, CLI commands, URLs to hit, UI elements to click, etc.
+  - Include expected results.
+  - Indicate if authorization is required.
+- The "happy path" should be included at the very least. Additional scenarios are encouraged.
+  - It is up to the code reviewers to go beyond the "happy path."
+  - It is up to the author to perform thorough manual testing before submitting a PR.
+
 ## Other information
 
 <!-- ✍️ Any additional context into the problem or why you solved it in the way you did -->


### PR DESCRIPTION
<!-- ✍️
- [x] Please check using "x" if your PR fulfills the following requirements -->
- [x] The title of the PR is formatted according to the semantic commit guidelines



## What is the current behavior?

<!-- ✍️ Describe and provide screenshots when applicable or remove this section entirely -->
There is no "How to Test" section

## What is the new behavior?

There is a "How to Test" section

I find that on most PRs it is helpful to code reviewers and new team members to have this information. 

On countless occasions, I've seen the process of authors going back and adding this section result in finding many bugs. This is a great quality control.

More often that not, I ask authors to back and add this section. Having it in the template will save time all around. 

When we start using GitHub template forms #1, this section could be optional or have N/A as a choice _if_ we want. 

<!-- ✍️ Describe or provide screenshots of the changes introduced -->
## Other Information

Please indicate any change in wording you'd like in your review. My goal is to get the subsection in and make it clear that _**manual**_ testing instructions go in it. Anything else can be changed if you think it is better. I don't want to overthink it though. 😄 
  
<!-- ✍️ Any additional context into the problem or why you solved it in the way you did -->

**Does this PR introduce a breaking change?** <!-- ✍️ Yes/No -->
<!-- ✍️ If necessary, please describe the impact and migration path -->
No