### PR TITLE
docs: add links to headings in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-epic.md
+++ b/.github/ISSUE_TEMPLATE/0-epic.md
@@ -15,11 +15,11 @@ The requirements document can be linked below for additional information.
 
 <!-- ✍️ Link to relevant resources for implementation, remove sections that don't apply  -->
 
-**Requirements document**
+#### Requirements document
 <!-- ✍️ Requirements -->
 
-**Design**
+#### Design
 <!-- ✍️ Figma link(s) -->
 
-**Architecture**
+#### Architecture
 <!-- ✍️ Diagrams or other overview -->

--- a/.github/ISSUE_TEMPLATE/0-epic.md
+++ b/.github/ISSUE_TEMPLATE/0-epic.md
@@ -11,15 +11,15 @@ the most relevant information from an implementation standpoint.
 
 The requirements document can be linked below for additional information.
 
-### Implementation resources
+### <a id="resources" />[#](#user-content-resources) Implementation resources
 
 <!-- ✍️ Link to relevant resources for implementation, remove sections that don't apply  -->
 
-#### Requirements document
+#### <a id="reqs" />[#](#user-content-reqs) Requirements document
 <!-- ✍️ Requirements -->
 
-#### Design
+#### <a id="design" />[#](#user-content-design) Design
 <!-- ✍️ Figma link(s) -->
 
-#### Architecture
+#### <a id="architecture" />[#](#user-content-architecture) Architecture
 <!-- ✍️ Diagrams or other overview -->

--- a/.github/ISSUE_TEMPLATE/1-design-spec.md
+++ b/.github/ISSUE_TEMPLATE/1-design-spec.md
@@ -15,7 +15,7 @@ A brief description of the requested functionality from the persona or business 
 <!-- ✍️ Define the user and their goal -->
 As a __target user__ I want to __describe goal__ so that __business value__.
 
-**Kano category**
+#### Kano category
 <!-- ✍️ Delighter/Performance/Baseline -->
 
 ### For research and discussion
@@ -28,13 +28,13 @@ _1. High level theory or question to be researched_
 
 <!-- ✍️ Link to relevant resources, remove sections that don't apply  -->
 
-**Business requirements**
+#### Business requirements
 <!-- ✍️ Link to "big picture" business requirement documents -->
 
-**References and Prior Art**
+#### References and Prior Art
 <!-- ✍️ Link to designs, patterns and other prior art for reference -->
 
-**Relevant issues**
+#### Relevant issues
 <!-- ✍️ Tag any relevant GitHub issues for context -->
 
 ## Deliverables

--- a/.github/ISSUE_TEMPLATE/1-design-spec.md
+++ b/.github/ISSUE_TEMPLATE/1-design-spec.md
@@ -6,38 +6,38 @@ about: User goals to be prototyped ahead of development
 <!-- ✍️ Context -->
 A brief description of the requested functionality from the persona or business value perspective. This should be written in language that a non-technical stakeholder can understand and should remain free of implementation details whenever possible. Sufficient context should be provided to any surrounding functionality to allow any team member to pick up the story without having to cross-reference other issues.
 
-### High level goals
+### <a id="goals" />[#](#user-content-goals) High level goals
 
 <!-- ✍️ Summarize two or three important things to consider -->
 
-### User story
+### <a id="story" />[#](#user-content-story) User story
 
 <!-- ✍️ Define the user and their goal -->
 As a __target user__ I want to __describe goal__ so that __business value__.
 
-#### Kano category
+#### <a id="kano" />[#](#user-content-kano) Kano category
 <!-- ✍️ Delighter/Performance/Baseline -->
 
-### For research and discussion
+### <a id="research" />[#](#user-content-research) For research and discussion
 
 _1. High level theory or question to be researched_
 
    Describe the theory and any motivation, prior discussions, or relevant feedback. These should complement the goals and requirements above but may be areas where we need more UX input or additional research before incorporating as a specific requirement.
 
-### Additional resources
+### <a id="resources" />[#](#user-content-resources) Additional resources
 
 <!-- ✍️ Link to relevant resources, remove sections that don't apply  -->
 
-#### Business requirements
+#### <a id="reqs" />[#](#user-content-reqs) Business requirements
 <!-- ✍️ Link to "big picture" business requirement documents -->
 
-#### References and Prior Art
+#### <a id="refs" />[#](#user-content-refs) References and Prior Art
 <!-- ✍️ Link to designs, patterns and other prior art for reference -->
 
-#### Relevant issues
+#### <a id="issues" />[#](#user-content-issues) Relevant issues
 <!-- ✍️ Tag any relevant GitHub issues for context -->
 
-## Deliverables
+## <a id="deliverables" />[#](#user-content-deliverables) Deliverables
 
 <!-- ✍️ This area will be blank until deliverables are complete
   Each should be represented as separate pages in the same Figma

--- a/.github/ISSUE_TEMPLATE/1-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.md
@@ -26,13 +26,13 @@ A brief description of the requested functionality from the persona or business 
 
 <!-- ✍️ Link to relevant resources for implementation, remove sections that don't apply  -->
 
-**Design**
+#### Design
 <!-- ✍️ Figma link(s) -->
 
-**Architecture**
+#### Architecture
 <!-- ✍️ Diagrams or other overview -->
 
-**References and Prior Art**
+#### References and Prior Art
 <!-- ✍️ Documentation or links to similar implementations -->
 
 ### Tasks

--- a/.github/ISSUE_TEMPLATE/1-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.md
@@ -7,14 +7,14 @@ about: New or improved user-facing functionality
 <!-- ✍️ Context -->
 A brief description of the requested functionality from the persona or business value perspective. This should be written in language that a non-technical stakeholder can understand and should remain free of implementation details whenever possible. Sufficient context should be provided to any surrounding functionality to allow any team member to pick up the story without having to cross-reference other issues.
 
-### <a id="demo" />[#](#demo) How to Demo
+### <a id="demo" />[#](#user-content-demo) How to Demo
 
 <!-- ✍️ -->
 1. These steps represent acceptance criteria for the work being performed.
 2. Avoid highly technical instruction so that a non-technical user can follow.
 3. These steps should be written from the perspective of the persona this story has been written for.
 
-### <a id="reqs" />[#](#reqs) Requirements
+### <a id="reqs" />[#](#user-content-reqs) Requirements
 
 <!-- ✍️ -->
 - A bulleted list of details that are important to either the persona or the business in order for this feature to deliver value.
@@ -22,20 +22,20 @@ A brief description of the requested functionality from the persona or business 
 - Additional context from a technical perspective can be bulleted here.
 - Naming expectations for model properties, variables, etc. should be clearly defined when important.
 
-### <a id="implementation" />[#](#implementation) Implementation resources
+### <a id="implementation" />[#](#user-content-implementation) Implementation resources
 
 <!-- ✍️ Link to relevant resources for implementation, remove sections that don't apply  -->
 
-#### <a id="design" />[#](#design) Design
+#### <a id="design" />[#](#user-content-design) Design
 <!-- ✍️ Figma link(s) -->
 
-#### <a id="architecture" />[#](#architecture) Architecture
+#### <a id="architecture" />[#](#user-content-architecture) Architecture
 <!-- ✍️ Diagrams or other overview -->
 
-#### <a id="refs" />[#](#refs) References and Prior Art
+#### <a id="refs" />[#](#user-content-refs) References and Prior Art
 <!-- ✍️ Documentation or links to similar implementations -->
 
-###  <a id="tasks" />[#](#tasks) Tasks
+###  <a id="tasks" />[#](#user-content-tasks) Tasks
 
 <!-- ✍️ -->
 - [ ] A checklist to the developer representing the steps necessary to implement.

--- a/.github/ISSUE_TEMPLATE/1-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.md
@@ -7,14 +7,14 @@ about: New or improved user-facing functionality
 <!-- ✍️ Context -->
 A brief description of the requested functionality from the persona or business value perspective. This should be written in language that a non-technical stakeholder can understand and should remain free of implementation details whenever possible. Sufficient context should be provided to any surrounding functionality to allow any team member to pick up the story without having to cross-reference other issues.
 
-### How to Demo
+### <a id="demo" />[#](#demo) How to Demo
 
 <!-- ✍️ -->
 1. These steps represent acceptance criteria for the work being performed.
 2. Avoid highly technical instruction so that a non-technical user can follow.
 3. These steps should be written from the perspective of the persona this story has been written for.
 
-### Requirements
+### <a id="reqs" />[#](#reqs) Requirements
 
 <!-- ✍️ -->
 - A bulleted list of details that are important to either the persona or the business in order for this feature to deliver value.
@@ -22,20 +22,20 @@ A brief description of the requested functionality from the persona or business 
 - Additional context from a technical perspective can be bulleted here.
 - Naming expectations for model properties, variables, etc. should be clearly defined when important.
 
-### Implementation resources
+### <a id="implementation" />[#](#implementation) Implementation resources
 
 <!-- ✍️ Link to relevant resources for implementation, remove sections that don't apply  -->
 
-#### Design
+#### <a id="design" />[#](#design) Design
 <!-- ✍️ Figma link(s) -->
 
-#### Architecture
+#### <a id="architecture" />[#](#architecture) Architecture
 <!-- ✍️ Diagrams or other overview -->
 
-#### References and Prior Art
+#### <a id="refs" />[#](#refs) References and Prior Art
 <!-- ✍️ Documentation or links to similar implementations -->
 
-### Tasks
+###  <a id="tasks" />[#](#tasks) Tasks
 
 <!-- ✍️ -->
 - [ ] A checklist to the developer representing the steps necessary to implement.

--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -6,30 +6,30 @@ about: Whoops, something went wrong...
 
 <!-- ✍️ Provide a clear and concise description of the problem -->
 
-### Minimal Reproduction
+### <a id="reproduction" />[#](#user-content-reproduction) Minimal Reproduction
 
 **Affected URL:**
 <!-- ✍️ -->
 
-#### Steps to Reproduce:
+#### <a id="steps" />[#](#user-content-steps) Steps to Reproduce:
 <!-- ✍️ -->
 1. The bug should be reproducible by following these steps.
 2. When possible provide enough specificity that anybody can reproduce.
 3.
 
-#### Expected Behavior:
+#### <a id="expected" />[#](#user-content-expected) Expected Behavior:
 <!-- ✍️ -->
 
-#### Actual Behavior:
+#### <a id="actual" />[#](#user-content-actual) Actual Behavior:
 <!-- ✍️ -->
 
-### Screenshot
+### <a id="screenshot" />[#](#user-content-screenshot) Screenshot
 
 <!-- ✍️ -->
 Often a screenshot can help to capture the issue better than a long description.
 Do not attach screenshots of console errors, copy and paste them below.
 
-### Exception or Error
+### <a id="error" />[#](#user-content-error) Exception or Error
 
 <!-- ✍️ -->
 ```
@@ -37,12 +37,12 @@ If there are console errors or an accompanying stack-trace, paste that here.
 If the exception was caught by Sentry, paste the link to that exception.
 ```
 
-### Your Environment
+### <a id="env" />[#](#user-content-env) Your Environment
 
 **Browser:** <!-- ✍️ -->
 **Operating system:** <!-- ✍️ -->
 **Reproducible on other systems?:** <!-- ✍️ Yes/No -->
 
-### Anything else relevant?
+### <a id="other" />[#](#user-content-other) Anything else relevant?
 
 <!-- ✍️ -->

--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -11,16 +11,16 @@ about: Whoops, something went wrong...
 **Affected URL:**
 <!-- ✍️ -->
 
-**Steps to Reproduce:**
+#### Steps to Reproduce:
 <!-- ✍️ -->
 1. The bug should be reproducible by following these steps.
 2. When possible provide enough specificity that anybody can reproduce.
 3.
 
-**Expected Behavior:**
+#### Expected Behavior:
 <!-- ✍️ -->
 
-**Actual Behavior:**
+#### Actual Behavior:
 <!-- ✍️ -->
 
 ### Screenshot

--- a/.github/ISSUE_TEMPLATE/3-testing-build.md
+++ b/.github/ISSUE_TEMPLATE/3-testing-build.md
@@ -5,12 +5,12 @@ about: System improvements or new capabilities
 
 <!-- ✍️ Provide a clear and concise description of the problem or missing capability -->
 
-### Describe the solution you'd like
+### <a id="solution" />[#](#user-content-solution) Describe the solution you'd like
 
 <!-- ✍️ -->
 If you have a solution in mind, please describe it.
 
-### Describe alternatives you've considered
+### <a id="alternatives" />[#](#user-content-alternatives) Describe alternatives you've considered
 
 <!-- ✍️ -->
 Have you considered any alternative solutions or workarounds?

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,23 +4,23 @@
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Functionality has been verified and is ready to be tested
 
-### Relevant issues
+### <a id="issues" />[#](#user-content-issues) Relevant issues
 
 <!-- ✍️ Tag any relevant GitHub issues, JIRA tickets, or paste links for additional context -->
 
-## What is the current behavior?
+## <a id="current" />[#](#user-content-current) What is the current behavior?
 
 <!-- ✍️ Describe and provide screenshots when applicable or remove this section entirely -->
 
-## What is the new behavior?
+## <a id="new" />[#](#user-content-new) What is the new behavior?
 
 <!-- ✍️ Describe or provide screenshots of the changes introduced -->
 
-### How to Test
+### <a id="testing" />[#](#user-content-testing) How to Test
 
 <!-- ✍️ Describe how to _manually_ test the new behavior -->
 
-## Other information
+## <a id="other" />[#](#user-content-other) Other information
 
 <!-- ✍️ Any additional context into the problem or why you solved it in the way you did -->
 


### PR DESCRIPTION
<!-- ✍️
- [x] Please check using "x" if your PR fulfills the following requirements -->
- [x] The title of the PR is formatted according to the semantic commit guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Functionality has been verified and is ready to be tested


## What is the current behavior?
We use bold text for subheadings which makes it difficult to further nest headings under that subheading



<!-- ✍️ Describe and provide screenshots when applicable or remove this section entirely -->

## What is the new behavior?
We use the next level down heading for subheadings

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#headings
<!-- ✍️ Describe or provide screenshots of the changes introduced -->

